### PR TITLE
1.3.1

### DIFF
--- a/src/builder/extension-builder/extension-builder.ts
+++ b/src/builder/extension-builder/extension-builder.ts
@@ -54,8 +54,9 @@ export class ExtensionBuilder extends WebpackBuilder {
 
     protected async beforeRun() {
         await super.beforeRun();
-        this.qrsService.certificateRoot
-            = "C:\\ProgramData\\Qlik\\Sense\\Repository\\Exported Certificates\\.Local Certificates";
+        const dir = process.env.ALLUSERSPROFILE;
+        this.qrsService.certificateRoot =
+            `${dir}\\Qlik\\Sense\\Repository\\Exported Certificates\\.Local Certificates`;
     }
 
     /**

--- a/src/builder/webpack-builder/service/webpack.service.ts
+++ b/src/builder/webpack-builder/service/webpack.service.ts
@@ -1,4 +1,4 @@
-import * as Webpack from "webpack";
+import * as webpack from "webpack";
 import { IOptionRuleSet } from "../../../api";
 import { BuilderConfigRules } from "../../../data";
 import { ConfigService } from "../../../services/config.service";
@@ -40,8 +40,9 @@ export class WebpackService extends ConfigService<WebpackConfigModel> {
      * @returns {Promise<Webpack.Compiler>}
      * @memberof WebpackService
      */
-    public async getWebpack(): Promise<Webpack.Compiler> {
-        return Webpack(await this.loadConfigurationFile());
+    public async getWebpack(): Promise<webpack.Compiler> {
+        const configuration = await this.loadConfigurationFile();
+        return webpack(configuration);
     }
 
     /**
@@ -77,7 +78,7 @@ export class WebpackService extends ConfigService<WebpackConfigModel> {
      * @returns {Promise<Webpack.Configuration>}
      * @memberof WebpackService
      */
-    private async loadConfigurationFile(): Promise<Webpack.Configuration> {
+    private async loadConfigurationFile(): Promise<webpack.Configuration> {
         const webpackConfig = await import("../templates/webpack.config");
         return webpackConfig.default;
     }

--- a/src/builder/webpack-builder/webpack-builder.ts
+++ b/src/builder/webpack-builder/webpack-builder.ts
@@ -3,6 +3,7 @@ import * as UglifyJSPlugin from "uglifyjs-3-webpack-plugin";
 import { Compiler, Module, Plugin } from "webpack";
 import { IBuilder, IBuilderEnvironment } from "../../api";
 import { IDataNode } from "../../api/data-node";
+import { WebpackConfigModel } from "./model/webpack-config.model";
 import { CleanWebpackPlugin, LogPlugin } from "./plugins";
 import { WebpackService } from "./service/webpack.service";
 
@@ -67,12 +68,15 @@ export class WebpackBuilder implements IBuilder {
 
         // set context paths were to watch for webpack plugins / loader
         settings.setLoaderContextPaths([
-            resolve(environment.builderRoot, "./dist/builder/webpack-builder/loader"),
-            resolve(environment.builderRoot, "./builder/webpack-builder/loader"),
-            resolve(environment.builderRoot, "./node_modules"),
-            resolve(environment.projectRoot, "./node_modules"),
+            resolve(__dirname, "./loader"),                     // own loaders
+            resolve(environment.builderRoot, "./node_modules"), // loaders in node_modules folder from q2g-build
+            resolve(environment.projectRoot, "./node_modules"), // loaders in project root node_modules folder
         ]);
         settings.setPackageName(environment.projectName);
+    }
+
+    public get settings(): WebpackConfigModel {
+        return this.webpackService.getConfig();
     }
 
     /**

--- a/src/package.json
+++ b/src/package.json
@@ -20,7 +20,6 @@
     "@types/node": "10.12.15",
     "@types/webpack": "4.4.21",
     "ajv": "6.6.2",
-    "uglifyjs-3-webpack-plugin": "1.2.4"
   },
   "dependencies": {
     "clean-webpack-plugin": "1.0.0",
@@ -39,6 +38,7 @@
     "url-loader": "1.1.2",
     "webpack": "4.27.1",
     "webpack-cli": "3.1.2",
-    "zip-webpack-plugin": "3.0.0"
+    "zip-webpack-plugin": "3.0.0",
+    "uglifyjs-3-webpack-plugin": "1.2.4"
   }
 }

--- a/src/services/builder.service.ts
+++ b/src/services/builder.service.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "fs";
 import { basename, resolve } from "path";
 import { Builders, IBuilder, IBuilderEnvironment } from "../api";
 import { IDataNode } from "../api/data-node";
@@ -112,8 +111,8 @@ export class BuilderService {
     }
 
     /**
-     * get builder root directory, this is the path where we can find
-     * the node_modules folder for q2g_build
+     * get directory from this script and go up and search for a directory
+     * which is called q2g-build. By general this should be in node_modules
      *
      * @private
      * @returns {string}
@@ -121,7 +120,7 @@ export class BuilderService {
      */
     private resolveBuilderRootDir(): string {
         let currentPath = __dirname;
-        while (!existsSync(resolve(currentPath, "node_modules")) || basename(currentPath) === "q2g-build") {
+        while (basename(currentPath) !== "q2g-build") {
             currentPath = resolve(currentPath, "..");
         }
         return currentPath;


### PR DESCRIPTION
Bugfix: ContextPaths for loaders are wrong 
Bugfix: Add missing dependency for q2g-build to uglify webpack bundle

Improve Loader Context paths so it will allways look in webpack-builder/loader directory to improve local development environment (like symlinks to q2g-build folder).