### PR TITLE
Version 2.0.0

### DIFF
--- a/src/api/builder-environment.interface.ts
+++ b/src/api/builder-environment.interface.ts
@@ -8,6 +8,8 @@ export interface IBuilderEnvironment {
      */
     builderRoot?: string;
 
+    typingsRoot?: string;
+
     /**
      * envrionment mode
      *

--- a/src/builder/extension-builder/extension-builder.ts
+++ b/src/builder/extension-builder/extension-builder.ts
@@ -1,4 +1,4 @@
-import * as CleanWebpackPlugin from "clean-webpack-plugin";
+import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import { existsSync, readFileSync } from "fs";
 import { resolve } from "path";
 import { Plugin } from "webpack";
@@ -88,7 +88,7 @@ export class ExtensionBuilder extends WebpackBuilder {
 
         const plugins = [
             new LogPlugin(),
-            new CleanWebpackPlugin.default({
+            new CleanWebpackPlugin({
                 cleanAfterEveryBuildPatterns: ["!**/wbfolder.wbl"],
             }),
             new PathOverridePlugin(/\/umd\//, "/esm/"),

--- a/src/builder/extension-builder/extension-builder.ts
+++ b/src/builder/extension-builder/extension-builder.ts
@@ -133,10 +133,7 @@ export class ExtensionBuilder extends WebpackBuilder {
      * @param name
      */
     private createDeployPlugin(name: string): DeployExtensionPlugin {
-
         const config: WebpackConfigModel = this.webpackService.getConfig();
-        const configDirectory = resolve(config.getProjectSource());
-
         return new DeployExtensionPlugin(config.getOutFileName(), config.getOutDirectory(), this.getCIConfiguration());
     }
 

--- a/src/builder/extension-builder/extension-builder.ts
+++ b/src/builder/extension-builder/extension-builder.ts
@@ -43,6 +43,7 @@ export class ExtensionBuilder extends WebpackBuilder {
 
         this.webpackService.getConfig().setExternalModules([
             { angular: "angular" },
+            { jquery: "jquery" },
             { qlik: "qlik" },
             { qvangular: "qvangular" },
         ]);

--- a/src/builder/extension-builder/plugins/qext/qext-file.plugin.ts
+++ b/src/builder/extension-builder/plugins/qext/qext-file.plugin.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from "fs";
+import { readFileSync, statSync, existsSync } from "fs";
 import { basename } from "path";
 import { compilation, Compiler } from "webpack";
 import { IQextData } from "../../../qext-file-builder/api";
@@ -33,15 +33,17 @@ export class QextFilePlugin {
             callback,
         ) => {
             const filePath = await this.qextBuilder.run();
-            const fileName = basename(filePath);
+            const fileName  = basename(filePath);
             const fileStats = statSync(filePath);
+            const fileContent = readFileSync(filePath);
 
             comp.assets[fileName] = {
                 size: () => {
                     return fileStats.size;
                 },
                 source: () => {
-                    return readFileSync(filePath);
+                    /** file not exists anymore ...  */
+                    return fileContent;
                 },
             };
             callback();

--- a/src/builder/qext-file-builder/qext-file.builder.ts
+++ b/src/builder/qext-file-builder/qext-file.builder.ts
@@ -4,6 +4,7 @@ import { IQextData } from "./api";
 import { QextConfigurationException } from "./data/exception/qext-config.exception";
 import { QextConfigService } from "./services/qext-config.service";
 import { QextFileService } from "./services/qext-file.service";
+import { existsSync } from "fs";
 
 export class QextFileBuilder implements IBuilder {
 
@@ -47,7 +48,7 @@ export class QextFileBuilder implements IBuilder {
         });
 
         if ( hasError ) {
-            throw new QextConfigurationException( JSON.stringify(errors) );
+            throw new QextConfigurationException(JSON.stringify(errors));
         }
     }
 

--- a/src/builder/qext-file-builder/services/qext-file.service.ts
+++ b/src/builder/qext-file-builder/services/qext-file.service.ts
@@ -18,6 +18,7 @@ export class QextFileService {
         if (!existsSync(outDirectory)) {
             this.createDirectory(outDirectory);
         }
+
         writeFileSync(filePath, JSON.stringify(data, null, 4), { encoding: "utf8" });
         return filePath;
     }

--- a/src/builder/webpack-builder/loader/sanitize-html-imports.loader.ts
+++ b/src/builder/webpack-builder/loader/sanitize-html-imports.loader.ts
@@ -1,0 +1,20 @@
+/**
+ * sanitize html imports
+ *
+ * convert: import * as template from "text!./my.file.html"
+ * into: import template from "my.file.html"
+ *
+ * @package q2g-builder
+ * @author Ralf Hannuschka
+ */
+export default function sanitizeHtmlImportsLoader(source) {
+
+    const importPattern = /import (?:\* as\s)?([^\s]+).*?("|')(?:text!)?(.*\.html)\2/;
+
+    /** loop through all matches and replace them */
+    const ret = source.replace(importPattern, (fullMatch, name, quoteChar, path) => {
+        return `import ${name} from ${quoteChar}${path}${quoteChar}`;
+    });
+
+    return ret;
+}

--- a/src/builder/webpack-builder/model/webpack-config.model.ts
+++ b/src/builder/webpack-builder/model/webpack-config.model.ts
@@ -1,4 +1,3 @@
-import { basename } from "path";
 import { Module, Options, Plugin } from "webpack";
 import { IDataNode } from "../../../api/data-node";
 import { ConfigModel } from "../../../model/config.model";

--- a/src/builder/webpack-builder/plugins/log.plugin.ts
+++ b/src/builder/webpack-builder/plugins/log.plugin.ts
@@ -27,12 +27,8 @@ export class LogPlugin implements Plugin {
                 return;
             }
 
-            const statsJson: Stats.ToJsonOptions = result.toJson();
-            const stats = statsJson.valueOf() as IDataNode;
-            process.stderr.write(JSON.stringify(stats.errors));
-            const errors: string[] = stats.errors;
-
-            throw new Error(errors.join("\n"));
+            const statsJson: Stats.ToJsonOutput = result.toJson();
+            process.stderr.write(JSON.stringify(statsJson.errors, null, 4));
         });
     }
 }

--- a/src/builder/webpack-builder/service/webpack.service.ts
+++ b/src/builder/webpack-builder/service/webpack.service.ts
@@ -13,15 +13,6 @@ export class WebpackService extends ConfigService<WebpackConfigModel> {
         return this.instance;
     }
 
-    /**
-     * global config values service
-     *
-     * @private
-     * @type {Config}
-     * @memberof WebpackService
-     */
-    private configService: WebpackService;
-
     public constructor() {
         if (WebpackService.instance) {
             throw new Error("could not create instance of WebpackService, use WebpackService.getInstance() instead");
@@ -53,7 +44,6 @@ export class WebpackService extends ConfigService<WebpackConfigModel> {
      * @memberof WebpackService
      */
     protected getConfigRules(): IOptionRuleSet {
-
         return {
             ...BuilderConfigRules,
             ...WebpackOptionRules,

--- a/src/builder/webpack-builder/templates/module-rules.config.ts
+++ b/src/builder/webpack-builder/templates/module-rules.config.ts
@@ -22,7 +22,7 @@ const moduleRules: Module = {
     }, {
         test: /.*\.html$/,
         use: [{
-            loader: "html-loader",
+            loader: "raw-loader",
         }],
     }, {
         loader: "json-loader",
@@ -31,7 +31,8 @@ const moduleRules: Module = {
     }, {
         sideEffects: true,
         test: /.*\.tsx?$/,
-        use: [{
+        use: [
+        {
             loader: "ts-loader",
             options: {
                 compilerOptions: {
@@ -39,7 +40,9 @@ const moduleRules: Module = {
                 },
                 configFile: config.getTsConfigFile(),
             },
-        }],
+        },
+            { loader: "sanitize-html-imports.loader" },
+        ],
     }, {
         sideEffects: true,
         test: /\.scss$/,

--- a/src/builder/webpack-builder/templates/module-rules.config.ts
+++ b/src/builder/webpack-builder/templates/module-rules.config.ts
@@ -20,6 +20,11 @@ const moduleRules: Module = {
             loader: "raw-loader",
         }],
     }, {
+        test: /.*\.html$/,
+        use: [{
+            loader: "html-loader",
+        }],
+    }, {
         loader: "json-loader",
         test: /\.json/,
         type: "javascript/auto",

--- a/src/builder/webpack-builder/templates/webpack.config.ts
+++ b/src/builder/webpack-builder/templates/webpack.config.ts
@@ -1,4 +1,4 @@
-import { Configuration, Options } from "webpack";
+import { Configuration } from "webpack";
 import { WebpackService } from "../service/webpack.service";
 
 const config = WebpackService.getInstance().getConfig();

--- a/src/builder/webpack-builder/webpack-builder.ts
+++ b/src/builder/webpack-builder/webpack-builder.ts
@@ -183,7 +183,6 @@ export class WebpackBuilder implements IBuilder {
      * @memberof WebpackBuilder
      */
     protected loadWebpackPlugins(): Plugin[] {
-        const outDir = this.webpackService.getConfig().getOutDirectory();
         const plugins: Plugin[] = [
             new LogPlugin(),
             new CleanWebpackPlugin(),

--- a/src/builder/webpack-builder/webpack-builder.ts
+++ b/src/builder/webpack-builder/webpack-builder.ts
@@ -73,8 +73,9 @@ export class WebpackBuilder implements IBuilder {
             resolve(environment.builderRoot, "./node_modules"), // loaders in node_modules folder from q2g-build
             resolve(environment.projectRoot, "./node_modules"), // loaders in project root node_modules folder
             /** only for local development */
-            resolve(environment.builderRoot, "./src/node_modules"), // loaders in node_modules folder from q2g-build
+            resolve(environment.builderRoot, "./src/node_modules"), // loaders in node_modules folder from q2g-build,
         ]);
+
         settings.setPackageName(environment.projectName);
     }
 

--- a/src/builder/webpack-builder/webpack-builder.ts
+++ b/src/builder/webpack-builder/webpack-builder.ts
@@ -1,4 +1,4 @@
-import CleanWebpackPlugin from "clean-webpack-plugin";
+import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import { basename, resolve } from "path";
 import * as TerserWebpackPlugin from "terser-webpack-plugin";
 import { Compiler, Module, Plugin } from "webpack";
@@ -7,7 +7,6 @@ import { IDataNode } from "../../api/data-node";
 import { WebpackConfigModel } from "./model/webpack-config.model";
 import { LogPlugin } from "./plugins";
 import { WebpackService } from "./service/webpack.service";
-import webpackConfig from "./templates/webpack.config";
 
 /**
  * builder for webpack to bundle all files
@@ -184,9 +183,13 @@ export class WebpackBuilder implements IBuilder {
      * @memberof WebpackBuilder
      */
     protected loadWebpackPlugins(): Plugin[] {
+
+        /** cast to any to fix typings */
+        const cleanWebpackPlugin: Plugin = new CleanWebpackPlugin() as any;
+
         const plugins: Plugin[] = [
             new LogPlugin(),
-            new CleanWebpackPlugin(),
+            cleanWebpackPlugin,
         ];
         return plugins;
     }

--- a/src/builder/webpack-builder/webpack-builder.ts
+++ b/src/builder/webpack-builder/webpack-builder.ts
@@ -7,6 +7,7 @@ import { IDataNode } from "../../api/data-node";
 import { WebpackConfigModel } from "./model/webpack-config.model";
 import { LogPlugin } from "./plugins";
 import { WebpackService } from "./service/webpack.service";
+import webpackConfig from "./templates/webpack.config";
 
 /**
  * builder for webpack to bundle all files
@@ -113,7 +114,7 @@ export class WebpackBuilder implements IBuilder {
 
             if (watch) {
                 const watchOptions: Compiler.WatchOptions = {
-                    ignored: ["**/*.js", "**/node_modules"],
+                    ignored: [webPackConfig.getOutDirectory(), "**/node_modules"],
                 };
                 /** start watch mode */
                 compiler.watch(watchOptions, handler);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import * as copyfiles from "copyfiles";
 import { existsSync, readFileSync } from "fs";
 import { resolve } from "path";
 import { IBuilder, IBuilderEnvironment } from "./api";
@@ -88,6 +89,11 @@ function getBuilderConfiguration(path): IDataNode {
  */
 async function main(root: string, ...args: string[]) {
 
+    copyfiles([
+        resolve(__dirname, "typings/*.d.ts"),
+        resolve(process.cwd(), "node_modules/@types", "q2gb"),
+    ], true, () => void 0);
+
     const commandLineOptions  = builderService.readCommandLineArguments(args);
     const builderType: string = commandLineOptions.builder;
     const configFile: string  = commandLineOptions.config;
@@ -112,8 +118,6 @@ async function main(root: string, ...args: string[]) {
         process.exit(1);
     }
 }
-
-// export const doBuild = main;
 
 /**
  * call main method and pass process arguments, remove first argument

--- a/src/model/config.model.ts
+++ b/src/model/config.model.ts
@@ -114,5 +114,4 @@ export class ConfigModel {
     public setTsConfigFile(fileName: string) {
         this.tsConfigFile = fileName;
     }
-
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q2g-build",
-  "version": "1.5.0-beta.0",
+  "version": "1.0.5-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -4922,7 +4922,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "q2g-build",
-  "version": "1.0.5-beta.1",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1147,6 +1147,20 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
+      }
+    },
+    "copyfiles": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.2.0.tgz",
+      "integrity": "sha512-iJbHJI+8OKqsq+4JF0rqgRkZzo++jqO6Wf4FUU1JM41cJF6JcY5968XyF4tm3Kkm7ZOMrqlljdm8N9oyY5raGw==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^0.5.1",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "yargs": "^13.2.4"
       }
     },
     "core-util-is": {
@@ -3640,6 +3654,42 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
+    "noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         }
       }
     },

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -3028,9 +3028,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.tail": {
       "version": "4.1.1",
@@ -3246,9 +3246,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -4455,9 +4455,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -5104,35 +5104,14 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q2g-build",
-  "version": "1.0.5-beta.1",
+  "version": "2.0.1",
   "description": "general build process",
   "main": "dist/main.js",
   "module": "dist/main.js",
@@ -11,7 +11,7 @@
     "q2gb": "./dist/lib/cli/main.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && copyfiles typings/*.d.ts ./dist",
     "pkg:publish": "npm run build && node npm/publish"
   },
   "author": "Ralf Hannuschka",
@@ -19,7 +19,8 @@
   "devDependencies": {
     "@types/node": "10.17.13",
     "@types/webpack": "4.41.2",
-    "ajv": "6.11.0"
+    "ajv": "6.11.0",
+    "copyfiles": "^2.2.0"
   },
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
@@ -43,5 +44,6 @@
     "webpack": "4.41.5",
     "webpack-cli": "3.3.10",
     "zip-webpack-plugin": "3.0.0"
-  }
+  },
+  "types": "./dist/typings/index.d.ts"
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q2g-build",
-  "version": "1.5.0-beta.0",
+  "version": "1.0.5-beta.1",
   "description": "general build process",
   "main": "dist/main.js",
   "module": "dist/main.js",

--- a/src/package.json
+++ b/src/package.json
@@ -17,7 +17,7 @@
   "author": "Ralf Hannuschka",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "10.14.4",
+    "@types/node": "^10.14.4",
     "@types/webpack": "4.4.27",
     "ajv": "6.10.0"
   },

--- a/src/services/builder.service.ts
+++ b/src/services/builder.service.ts
@@ -100,8 +100,10 @@ export class BuilderService {
                 }
         }
 
+        const builderRootDirectory = env.builderRoot || this.resolveBuilderRootDir();
+
         builder.initialize({
-            builderRoot: env.builderRoot || this.resolveBuilderRootDir(),
+            builderRoot: builderRootDirectory ,
             environment: env.environment || "development",
             projectName: env.projectName || "q2g-project",
             projectRoot: env.projectRoot || ".",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -14,7 +14,7 @@
             "es6"
         ],
         "paths": {
-            "@builder/*": ["./builder/*"],
+            "@builder/*": ["./builder/*"]
         },
         "typeRoots": [
             "node_modules/@types",
@@ -28,6 +28,6 @@
         "**/*.js"
     ],
     "include": [
-       "**/*.ts",
+       "**/*.ts"
     ]
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -15,12 +15,7 @@
         ],
         "paths": {
             "@builder/*": ["./builder/*"]
-        },
-        "typeRoots": [
-            "node_modules/@types",
-            "typings"
-        ],
-        "types": ["node", "webpack"]
+        }
     },
     "exclude": [
         "node_modules",

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -1,0 +1,8 @@
+declare module '*.html' {
+  const value: string;
+  export default value
+}
+
+interface IQVAngular {
+    $injector: angular.auto.IInjectorService;
+}


### PR DESCRIPTION
Update to version 2.0.0

- BREAKING_CHANGE: update all packages (ts goes up to 3.7.x)
- feat: added ts loader to sanitize html imports since the old way not working anymore but so we dont need to change the imports
- feat: include typings file for html module

### HTML Imports

*before*

```ts
import * as template from "text!./my.template.html"
```

*after*

```ts
import template from "my.template.html"
```

There is no change in code required since we added a custom loader which sanitize the old imports and rewrites them to the new imports. If you want to use the new imports there is a typings file required, we copy this file from q2g-build into node_modules/@types/q2gb. If this is not working create your own with following content.

```ts
declare module "*.html" {
   const html: string;
   export default html;
}
```